### PR TITLE
Resolução do conflito em Game.over()

### DIFF
--- a/src/main/java/battleship/Game.java
+++ b/src/main/java/battleship/Game.java
@@ -458,11 +458,25 @@ public class Game implements IGame
 		Game.printBoard(this.alienFleet, this.myMoves, show_shots, show_legend);
 	}
 
-	public void over() {
-			System.out.println();
-			System.out.println("+--------------------------------------------------------------+");
-			System.out.println("| Maldito sejas, Java Sparrow, eu voltarei, glub glub glub ... |");
-			System.out.println("+--------------------------------------------------------------+");
-			GameReportPDF.generate(this);
-	}
+    /**
+     * Finalizes the game, prints a closing message and displays the total duration
+     * of the match.
+     *
+     * <p>
+     * This method stops the {@link GameTimer}, retrieves the total elapsed time
+     * since the beginning of the game, and prints it in a human-readable format.
+     * </p>
+     */
+    public void over() {
+        System.out.println();
+        System.out.println("+--------------------------------------------------------------+");
+        System.out.println("| Maldito sejas, Java Sparrow, eu voltarei, glub glub glub ... |");
+        System.out.println("+--------------------------------------------------------------+");
+
+        GameReportPDF.generate(this);
+
+        gameTimer.end();
+        System.out.println("Duração da partida: " + GameTimer.formatDuration(gameTimer.getDuration()));
+    }
+
 }


### PR DESCRIPTION
O término do relógio e a documentação Javadoc no método over() da classe Game tinham ficado perdidos devido a conflitos.

Com esta alteração, as três (3) funcionalidades implementadas até ao momento (#2, #3 e #4) estão todas em sintonia no main.